### PR TITLE
Allow data as json

### DIFF
--- a/klarnacheckout/connector.py
+++ b/klarnacheckout/connector.py
@@ -82,12 +82,11 @@ class Connector(object):
         if method == 'POST':
             req.add_header('Content-Type', content_type)
             data = options.get('data') or resource.marshal()
-            try:
-                # check if data is already valid JSON
-                json.loads(data)
-                req.data = data
-            except (TypeError, ValueError):
+            if hasattr(data, '__iter__'):
+                # data which is iterable must be serialized
                 req.data = json.dumps(data).encode('utf-8')
+            else:
+                req.data = data.encode('utf-8')
 
         return self.handle_response(resource, self.opener.open(req))
 

--- a/klarnacheckout/connector.py
+++ b/klarnacheckout/connector.py
@@ -82,7 +82,7 @@ class Connector(object):
         if method == 'POST':
             req.add_header('Content-Type', content_type)
             data = options.get('data') or resource.marshal()
-            if hasattr(data, '__iter__'):
+            if isinstance(data, (list, tuple, dict)):
                 # data which is iterable must be serialized
                 req.data = json.dumps(data).encode('utf-8')
             else:

--- a/klarnacheckout/connector.py
+++ b/klarnacheckout/connector.py
@@ -86,7 +86,7 @@ class Connector(object):
                 # check if data is already valid JSON
                 json.loads(data)
                 req.data = data
-            except ValueError:
+            except (TypeError, ValueError):
                 req.data = json.dumps(data).encode('utf-8')
 
         return self.handle_response(resource, self.opener.open(req))

--- a/klarnacheckout/connector.py
+++ b/klarnacheckout/connector.py
@@ -82,7 +82,12 @@ class Connector(object):
         if method == 'POST':
             req.add_header('Content-Type', content_type)
             data = options.get('data') or resource.marshal()
-            req.data = json.dumps(data).encode('utf-8')
+            try:
+                # check if data is already valid JSON
+                json.loads(data)
+                req.data = data
+            except ValueError:
+                req.data = json.dumps(data).encode('utf-8')
 
         return self.handle_response(resource, self.opener.open(req))
 

--- a/tests/unit/test_order.py
+++ b/tests/unit/test_order.py
@@ -97,6 +97,15 @@ class TestOrder(unittest.TestCase):
         self._connector.apply.assert_called_once_with(
             "POST", self._order, {"url": location, "data": data})
 
+    def test_create_json(self):
+        location = "http://stub"
+        self._order.base_uri = location
+        data = '{"foo": "boo"}'
+        self._order.create(data)
+
+        self._connector.apply.assert_called_once_with(
+            "POST", self._order, {"url": location, "data": data})
+
     def test_fetch(self):
         location = "http://stub"
         self._order.location = location


### PR DESCRIPTION
I use a REST service to serialize the cart. This REST service returns the carts content serialized in JSON format. Therefore I would have to convert it back to a Python dict, which doesn't make sense, since later it is has to be converted to JSON anyway.

Therefore I'd like to add a check, which bypasses the serialization, if the `data` object already is valid JSON.
